### PR TITLE
fix(cvrf): supplement recent months missing from the update index

### DIFF
--- a/pkg/vulnerability/fetcher/cvrf/cvrf.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
@@ -21,38 +22,99 @@ import (
 
 const (
 	updateListURL    = "https://api.msrc.microsoft.com/cvrf/v3.0/updates"
+	cvrfURLFormat    = "https://api.msrc.microsoft.com/cvrf/v3.0/cvrf/%s"
 	cveURLFormat     = "https://msrc.microsoft.com/update-guide/vulnerability/%s"
 	articleURLFormat = "https://support.microsoft.com/help/%s"
+
+	// recentMonths is how many of the most recent calendar months are always
+	// fetched, even when they are absent from the /updates index.
+	//
+	// Microsoft intermittently drops the newest month(s) from the /updates
+	// index for several hours (observed repeatedly for the freshly-released
+	// month, e.g. 2025-Oct and 2026-Jun, each vanishing and reappearing within
+	// hours). Because the index is the only source of months to fetch and the
+	// fetch step wipes ./dist/vulnerability/cvrf with RemoveAll, such a
+	// transient dropout would delete that whole month from the feed. Force-
+	// fetching the recent months by their deterministic CVRF URL keeps them in
+	// the feed across these index dropouts.
+	recentMonths = 3
 )
+
+// cvrfTarget is a month document to fetch. fromIndex records whether the month
+// was advertised by the /updates index (true) or supplemented as a recent month
+// that was missing from the index (false). The two are handled differently on
+// failure: an index-listed month that returns non-200 or an empty document is
+// treated as an error (fail-closed, so we never wipe existing data on a
+// transient upstream glitch), whereas a supplemented month that is unavailable
+// is simply skipped (it may not be published yet, e.g. before Patch Tuesday).
+type cvrfTarget struct {
+	id        string
+	url       string
+	fromIndex bool
+}
 
 // FetchandParse ...
 func FetchandParse() ([]model.Vulnerability, error) {
 	log.Printf("INFO: fetch CVRF Updates. URL: %s", updateListURL)
-	cvrfURLs, err := fetchCVRFURLs()
+	targets, err := fetchCVRFTargets()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch CVRF URLs from updates")
+		return nil, errors.Wrap(err, "failed to fetch CVRF targets from updates")
 	}
 
-	cves := []model.Vulnerability{}
-	for _, cvrfURL := range cvrfURLs {
-		log.Printf("INFO: fetch CVRF. URL: %s", cvrfURL)
-		root, err := fetchCVRF(cvrfURL)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to fetch CVRF. url: %s", cvrfURL)
-		}
-		cs, err := Parse(root)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse CVRF. url: %s", cvrfURL)
-		}
-		log.Printf("INFO: %d CVEs found from %s", len(cs), cvrfURL)
-		cves = append(cves, cs...)
+	cves, err := collectVulnerabilities(targets)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to collect vulnerabilities")
 	}
 	log.Printf("INFO: %d CVEs found", len(cves))
 
 	return cves, nil
 }
 
-func fetchCVRFURLs() ([]string, error) {
+// collectVulnerabilities fetches and parses every target, applying the Layer 2
+// failure handling: an index-listed month that is unfetchable or empty is a
+// hard error (fail-closed, so the downstream RemoveAll never wipes existing
+// data on a transient upstream glitch), whereas a supplemented month that is
+// unavailable is skipped.
+func collectVulnerabilities(targets []cvrfTarget) ([]model.Vulnerability, error) {
+	cves := []model.Vulnerability{}
+	for _, t := range targets {
+		log.Printf("INFO: fetch CVRF. URL: %s", t.url)
+		root, err := fetchCVRF(t.url)
+		if err != nil {
+			if !t.fromIndex {
+				log.Printf("INFO: skip supplemented month %s (not available: %v)", t.id, err)
+				continue
+			}
+			return nil, errors.Wrapf(err, "failed to fetch CVRF listed in index. url: %s", t.url)
+		}
+
+		cs, err := Parse(root)
+		if err != nil {
+			if !t.fromIndex {
+				log.Printf("INFO: skip supplemented month %s (failed to parse. err: %v)", t.id, err)
+				continue
+			}
+			return nil, errors.Wrapf(err, "failed to parse CVRF. url: %s", t.url)
+		}
+
+		// Layer 2: never accept an empty document silently. An index-listed
+		// month with zero vulnerabilities is the "200 but empty" dropout; treat
+		// it as an error so the downstream RemoveAll does not wipe the month.
+		if len(cs) == 0 {
+			if !t.fromIndex {
+				log.Printf("INFO: skip supplemented month %s (0 vulnerabilities)", t.id)
+				continue
+			}
+			return nil, errors.Errorf("month %s is listed in the index but contains 0 vulnerabilities; refusing to proceed to avoid wiping existing data", t.id)
+		}
+
+		log.Printf("INFO: %d CVEs found from %s", len(cs), t.url)
+		cves = append(cves, cs...)
+	}
+	return cves, nil
+}
+
+func fetchCVRFTargets() ([]cvrfTarget, error) {
 	req, err := http.NewRequest(http.MethodGet, updateListURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build request")
@@ -71,19 +133,54 @@ func fetchCVRFURLs() ([]string, error) {
 		return nil, errors.Wrap(err, "failed to decode json")
 	}
 
-	urls := []string{}
+	urls := make([]string, 0, len(us.Value))
 	for _, u := range us.Value {
-		uu, err := url.Parse(u.CvrfURL)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse url")
-		}
-		if path.Base(uu.Path) == "document" {
-			continue
-		}
 		urls = append(urls, u.CvrfURL)
 	}
 
-	return urls, nil
+	return buildTargets(urls, time.Now().UTC(), recentMonths)
+}
+
+// buildTargets merges the month documents advertised by the /updates index with
+// the most recent `recent` calendar months (Layer 1). Recent months missing
+// from the index are added with a deterministically reconstructed CVRF URL so
+// that a transient index dropout of the newest month does not remove it from the
+// feed. now is passed in (instead of calling time.Now) to keep this testable.
+func buildTargets(indexURLs []string, now time.Time, recent int) ([]cvrfTarget, error) {
+	targets := []cvrfTarget{}
+	seen := map[string]bool{}
+
+	for _, u := range indexURLs {
+		uu, err := url.Parse(u)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse url")
+		}
+		id := path.Base(uu.Path)
+		if id == "document" {
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		targets = append(targets, cvrfTarget{id: id, url: u, fromIndex: true})
+		seen[id] = true
+	}
+
+	// Anchor at the first of the current month so subtracting months never
+	// overflows on 29-31 day boundaries (Go's AddDate normalizes e.g. Jul 31 - 1
+	// month to Jul 1).
+	base := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < recent; i++ {
+		id := base.AddDate(0, -i, 0).Format("2006-Jan")
+		if seen[id] {
+			continue
+		}
+		targets = append(targets, cvrfTarget{id: id, url: fmt.Sprintf(cvrfURLFormat, id), fromIndex: false})
+		seen[id] = true
+		log.Printf("INFO: month %s is missing from the update index; supplementing it (recent %d months are always fetched)", id, recent)
+	}
+
+	return targets, nil
 }
 
 func fetchCVRF(cvrfURL string) (Doc, error) {
@@ -99,6 +196,10 @@ func fetchCVRF(cvrfURL string) (Doc, error) {
 		return Doc{}, errors.Wrap(err, "failed to do request")
 	}
 	defer closeutil.Quietly(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return Doc{}, errors.Errorf("unexpected HTTP status %s", resp.Status)
+	}
 
 	var root Doc
 	if err := xml.NewDecoder(resp.Body).Decode(&root); err != nil {

--- a/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
@@ -2,8 +2,13 @@ package cvrf
 
 import (
 	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -230,5 +235,196 @@ func TestParse(t *testing.T) {
 		if diff := cmp.Diff(tt.expected, got, opts...); diff != "" {
 			t.Errorf("[%d] failed to Parse(). (-expected +got):\n%s", i, diff)
 		}
+	}
+}
+
+func targetIDs(ts []cvrfTarget) []string {
+	ids := make([]string, 0, len(ts))
+	for _, t := range ts {
+		ids = append(ids, t.id)
+	}
+	return ids
+}
+
+func TestBuildTargets(t *testing.T) {
+	const base = "https://api.msrc.microsoft.com/cvrf/v3.0/cvrf/"
+	now := time.Date(2026, time.July, 2, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		indexURLs   []string
+		recent      int
+		wantIDs     []string
+		wantMissing map[string]bool // ids expected to have fromIndex == false
+	}{
+		{
+			name: "recent month dropped from index is supplemented",
+			// 2026-Jun is missing from the index (the observed dropout).
+			indexURLs: []string{
+				base + "2026-Jul",
+				base + "2026-May",
+				base + "2026-Apr",
+			},
+			recent:      3,
+			wantIDs:     []string{"2026-Jul", "2026-May", "2026-Apr", "2026-Jun"},
+			wantMissing: map[string]bool{"2026-Jun": true},
+		},
+		{
+			name: "no supplement when all recent months present",
+			indexURLs: []string{
+				base + "2026-Jul",
+				base + "2026-Jun",
+				base + "2026-May",
+			},
+			recent:      3,
+			wantIDs:     []string{"2026-Jul", "2026-Jun", "2026-May"},
+			wantMissing: map[string]bool{},
+		},
+		{
+			name: "document entries are skipped, current month supplemented",
+			indexURLs: []string{
+				base + "2026-Jun",
+				base + "2026-May",
+				"https://api.msrc.microsoft.com/cvrf/v3.0/document/2026-Jun",
+			},
+			recent:  3,
+			wantIDs: []string{"2026-Jun", "2026-May", "2026-Jul"},
+			// recent=3 -> Jul, Jun, May. Jun & May already present, so only Jul
+			// is supplemented.
+			wantMissing: map[string]bool{"2026-Jul": true},
+		},
+		{
+			name:        "empty index supplements the whole recent window",
+			indexURLs:   nil,
+			recent:      3,
+			wantIDs:     []string{"2026-Jul", "2026-Jun", "2026-May"},
+			wantMissing: map[string]bool{"2026-Jul": true, "2026-Jun": true, "2026-May": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildTargets(tt.indexURLs, now, tt.recent)
+			if err != nil {
+				t.Fatalf("buildTargets returned error: %s", err)
+			}
+			if diff := cmp.Diff(tt.wantIDs, targetIDs(got),
+				cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+				t.Errorf("target ids mismatch (-want +got):\n%s", diff)
+			}
+			for _, tg := range got {
+				wantFromIndex := !tt.wantMissing[tg.id]
+				if tg.fromIndex != wantFromIndex {
+					t.Errorf("target %s: fromIndex = %v, want %v", tg.id, tg.fromIndex, wantFromIndex)
+				}
+				if !tg.fromIndex && tg.url != base+tg.id {
+					t.Errorf("supplemented target %s: url = %s, want reconstructed %s", tg.id, tg.url, base+tg.id)
+				}
+			}
+		})
+	}
+}
+
+// TestBuildTargetsMonthEndDoesNotOverflow guards the AddDate day-overflow trap:
+// on the 31st, naive now.AddDate(0, -1, 0) would skip a month.
+func TestBuildTargetsMonthEndDoesNotOverflow(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 0, 0, 0, 0, time.UTC)
+	got, err := buildTargets(nil, now, 3)
+	if err != nil {
+		t.Fatalf("buildTargets returned error: %s", err)
+	}
+	want := []string{"2026-Jul", "2026-Jun", "2026-May"}
+	if diff := cmp.Diff(want, targetIDs(got)); diff != "" {
+		t.Errorf("month-end target ids mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCollectVulnerabilities(t *testing.T) {
+	// 2022-May.xml parses to 2 vulnerabilities; used as a "healthy" response.
+	populated, err := os.ReadFile("./testdata/2022-May.xml")
+	if err != nil {
+		t.Fatalf("read testdata: %s", err)
+	}
+	// A well-formed CVRF document that contains no <Vulnerability> elements,
+	// i.e. the "200 but empty" dropout. Parses to 0 vulnerabilities.
+	const emptyDoc = `<?xml version="1.0" encoding="utf-8"?><cvrfdoc></cvrfdoc>`
+
+	// The test server routes by path: "/<id>" for a healthy doc, "/empty/<id>"
+	// for an empty doc, and any unmapped path returns 404.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/2022-May" || r.URL.Path == "/2026-Jun":
+			_, _ = w.Write(populated)
+		case strings.HasPrefix(r.URL.Path, "/empty/"):
+			_, _ = io.WriteString(w, emptyDoc)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	u := func(p string) string { return srv.URL + p }
+
+	tests := []struct {
+		name     string
+		targets  []cvrfTarget
+		wantCVEs int
+		wantErr  bool
+	}{
+		{
+			name:     "healthy index month is included",
+			targets:  []cvrfTarget{{id: "2022-May", url: u("/2022-May"), fromIndex: true}},
+			wantCVEs: 2,
+		},
+		{
+			name:     "supplemented dropped month is recovered",
+			targets:  []cvrfTarget{{id: "2026-Jun", url: u("/2026-Jun"), fromIndex: false}},
+			wantCVEs: 2,
+		},
+		{
+			name:    "index month returning HTTP 404 fails closed",
+			targets: []cvrfTarget{{id: "2026-Jul", url: u("/2026-Jul"), fromIndex: true}},
+			wantErr: true,
+		},
+		{
+			name:    "index month with 0 vulnerabilities fails closed",
+			targets: []cvrfTarget{{id: "2026-Jul", url: u("/empty/2026-Jul"), fromIndex: true}},
+			wantErr: true,
+		},
+		{
+			name:     "supplemented month unavailable is skipped, not fatal",
+			targets:  []cvrfTarget{{id: "2026-Jul", url: u("/2026-Jul"), fromIndex: false}},
+			wantCVEs: 0,
+		},
+		{
+			name:     "supplemented month with 0 vulnerabilities is skipped",
+			targets:  []cvrfTarget{{id: "2026-Jul", url: u("/empty/2026-Jul"), fromIndex: false}},
+			wantCVEs: 0,
+		},
+		{
+			name: "healthy index month plus skipped supplemented month",
+			targets: []cvrfTarget{
+				{id: "2022-May", url: u("/2022-May"), fromIndex: true},
+				{id: "2026-Jul", url: u("/2026-Jul"), fromIndex: false},
+			},
+			wantCVEs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := collectVulnerabilities(tt.targets)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (%d CVEs)", len(got))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if len(got) != tt.wantCVEs {
+				t.Errorf("got %d CVEs, want %d", len(got), tt.wantCVEs)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Background / Problem

`fetch vulnerability cvrf` fetches only the months advertised by the `/updates` index, then wipes `./dist/vulnerability/cvrf` with `RemoveAll` before writing the result back. However, Microsoft's `/updates` index intermittently **drops the freshly-released newest month for a few hours**. If a fetch runs during that window, the month is not in the index → it is never fetched → `RemoveAll` **deletes that entire month from the feed**, causing Windows detection gaps in downstream DBs.

### Evidence from real snapshots

Scanning the git history of `vuls-data-raw-microsoft-cvrf` (2023-11 → 2026-07, 1005 commits) surfaces the whole-month deletions where this bug actually fired:

| Occurred (UTC) | Month | Files deleted | Time until restored |
|---|---|---|---|
| 2025-10-10 | 2025-Oct | 53 | ~4 days |
| 2026-06-16 | 2026-Jun | 723 | ~13.5 hours |
| 2026-07-02 | 2026-Jun | 1273 (all) | ~11.5 hours |

- Zero occurrences between 2023-11 and 2025-09; the transient dropout of the newest month **started appearing in 2025-10 and is becoming recurring**.
- A separate hourly snapshot captured yet another 2026-Jun dropout (night of 07-02) not present above, so a daily-ish history **undercounts** the real frequency.

Given that recent months are the ones that disappear, this PR **supplements the most recent N months independently of the index**.

## Changes

### Layer 1 — supplement recent months
- Rename `fetchCVRFURLs` → `fetchCVRFTargets`, and extract a pure function `buildTargets(indexURLs, now, recent)` (network-free, unit-testable).
- Union the index's month set with the **most recent `recentMonths` (=3) calendar months**, deduplicated. For a recent month absent from the index, reconstruct its deterministic CVRF URL (`.../cvrf/v3.0/cvrf/<ID>`) and fetch it directly.
- Tag each target with `fromIndex bool` (`cvrfTarget`) to drive failure handling.
- Month-end overflow guard: `AddDate` would skip a month on e.g. Jul 31 → Jul 1, so **anchor to the first day of the current month before subtracting**.

### Layer 2 — do not accept empty/error responses silently
- `fetchCVRF` now returns the HTTP status (previously it ignored the status and decoded the body regardless).
- Failure handling in `collectVulnerabilities`:

| Case | Index-listed month | Supplemented month |
|---|---|---|
| non-200 / decode error | **error, fail-closed** | skip (e.g. not yet published before Patch Tuesday) |
| 200 but 0 vulnerabilities | **error, fail-closed** | skip |
| 200 with >=1 vulnerability | included | included (recovers the dropped month) |

Asymmetric by design: if the index claims a month exists but it returns empty/404, we **error out and preserve the previous feed** (RemoveAll never runs); if a supplemented month is simply not available yet, we **skip it quietly**.

## Tests
- `TestBuildTargets` (dropped month supplemented / no supplement when all present / `document` entries skipped / empty index).
- `TestBuildTargetsMonthEndDoesNotOverflow` (month-end `AddDate` regression guard).
- `TestCollectVulnerabilities` (healthy / dropped month recovered / index month 404 -> error / index month 0 vulns -> error / supplemented month 404 -> skip / supplemented month 0 vulns -> skip / mixed).
- Existing `TestParse` (including the `error.xml` case) is preserved.

`go build ./...`, `go vet`, `gofmt -l`, and `go test` are all green.

## Notes
- `recentMonths` is a single const (default 3 = current + previous 2), weighted toward recent months since those are the ones targeted.
- A broader "shrink fail-closed guard" (compare against the previous feed to catch any unexpected shrinkage) can follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)