### PR TITLE
fix(lint): resolve pre-existing golangci-lint failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("%+v", err))
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/closeutil/closeutil.go
+++ b/pkg/closeutil/closeutil.go
@@ -1,0 +1,14 @@
+// Package closeutil provides small helpers for closing io.Closers.
+package closeutil
+
+import "io"
+
+// Quietly closes c and ignores the returned error. Use it where a Close
+// failure is not actionable: read-side closers (HTTP response bodies, files
+// opened for reading) and plain *os.File writes, whose write errors already
+// surface at Write time. Buffered write paths (e.g. gzip.Writer) must check the
+// Close error instead, because it can report a flush failure that truncates the
+// output.
+func Quietly(c io.Closer) {
+	_ = c.Close()
+}

--- a/pkg/closeutil/closeutil.go
+++ b/pkg/closeutil/closeutil.go
@@ -3,12 +3,15 @@ package closeutil
 
 import "io"
 
-// Quietly closes c and ignores the returned error. Use it where a Close
-// failure is not actionable: read-side closers (HTTP response bodies, files
-// opened for reading) and plain *os.File writes, whose write errors already
-// surface at Write time. Buffered write paths (e.g. gzip.Writer) must check the
-// Close error instead, because it can report a flush failure that truncates the
-// output.
+// Quietly closes c, deliberately discarding the error. Use it only where the
+// Close error is not actionable: read-side closers (HTTP response bodies, files
+// opened for reading), and outputs whose truncation would be caught by a later
+// stage (e.g. a JSON file that is re-parsed downstream).
+//
+// Do NOT use it when a silently truncated output would go undetected. Close can
+// be the first place a deferred write error surfaces (e.g. on NFS/remote
+// filesystems, or with buffered writers such as gzip.Writer), so those write
+// paths must check the Close error explicitly instead.
 func Quietly(c io.Closer) {
 	_ = c.Close()
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"compress/gzip"
 	"encoding/json"
+	stderrors "errors"
 	"os"
 
 	"github.com/pkg/errors"
@@ -85,31 +86,31 @@ var buildCmd = &cobra.Command{
 
 // writeGzipJSON writes v as gzip-compressed JSON to path. Because gzip.Writer
 // buffers and its Close flushes the remaining data and writes the stream
-// footer, a swallowed Close error can silently produce a truncated .gz; the
-// close errors of both the gzip writer and the underlying file are therefore
-// propagated via the named return.
-func writeGzipJSON(path string, v any) (err error) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
+// footer, a swallowed Close error can silently produce a truncated .gz. The
+// gzip writer is therefore closed before the file (so the footer is flushed
+// first), and the encode error together with both Close errors are combined so
+// no failure is dropped.
+func writeGzipJSON(path string, v any) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open %s", path)
 	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = errors.Wrapf(cerr, "failed to close %s", path)
-		}
-	}()
 
 	w := gzip.NewWriter(f)
-	defer func() {
-		if cerr := w.Close(); cerr != nil && err == nil {
-			err = errors.Wrapf(cerr, "failed to close gzip writer for %s", path)
-		}
-	}()
-
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		return errors.Wrapf(err, "failed to encode %s", path)
+	encErr := json.NewEncoder(w).Encode(v)
+	if encErr != nil {
+		encErr = errors.Wrapf(encErr, "failed to encode %s", path)
 	}
-	return nil
+	wErr := w.Close()
+	if wErr != nil {
+		wErr = errors.Wrapf(wErr, "failed to close gzip writer for %s", path)
+	}
+	fErr := f.Close()
+	if fErr != nil {
+		fErr = errors.Wrapf(fErr, "failed to close %s", path)
+	}
+
+	return stderrors.Join(encErr, wErr, fErr)
 }
 
 func init() {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -64,9 +64,9 @@ var buildCmd = &cobra.Command{
 			if err != nil {
 				return errors.Wrap(err, "failed to open vulnerability/vulnerability.json.gz")
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 			w := gzip.NewWriter(f)
-			defer w.Close()
+			defer func() { _ = w.Close() }()
 			if err := json.NewEncoder(w).Encode(cves); err != nil {
 				return errors.Wrap(err, "failed to encode vulnerability/vulnerability.json.gz")
 			}
@@ -86,9 +86,9 @@ var buildCmd = &cobra.Command{
 			if err != nil {
 				return errors.Wrap(err, "failed to open supercedence/supercedence.json.gz")
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 			w := gzip.NewWriter(f)
-			defer w.Close()
+			defer func() { _ = w.Close() }()
 			if err := json.NewEncoder(w).Encode(supercedences); err != nil {
 				return errors.Wrap(err, "failed to encode supercedence/supercedence.json.gz")
 			}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -60,15 +60,8 @@ var buildCmd = &cobra.Command{
 				}
 			}
 
-			f, err := os.OpenFile("./dist/vulnerability/vulnerability.json.gz", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-			if err != nil {
-				return errors.Wrap(err, "failed to open vulnerability/vulnerability.json.gz")
-			}
-			defer func() { _ = f.Close() }()
-			w := gzip.NewWriter(f)
-			defer func() { _ = w.Close() }()
-			if err := json.NewEncoder(w).Encode(cves); err != nil {
-				return errors.Wrap(err, "failed to encode vulnerability/vulnerability.json.gz")
+			if err := writeGzipJSON("./dist/vulnerability/vulnerability.json.gz", cves); err != nil {
+				return errors.Wrap(err, "failed to write vulnerability/vulnerability.json.gz")
 			}
 		case "supercedence":
 			supercedences, err := supercedenceBuilder.Build([]string{"./dist/supercedence/bulletin", "./dist/supercedence/cvrf", "./dist/supercedence/wsusscn2", "./dist/supercedence/msuc", "./dist/supercedence/manual"})
@@ -82,19 +75,41 @@ var buildCmd = &cobra.Command{
 				slices.Sort(supercedences[i].Supersededby.KBIDs)
 			}
 
-			f, err := os.OpenFile("./dist/supercedence/supercedence.json.gz", os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
-			if err != nil {
-				return errors.Wrap(err, "failed to open supercedence/supercedence.json.gz")
-			}
-			defer func() { _ = f.Close() }()
-			w := gzip.NewWriter(f)
-			defer func() { _ = w.Close() }()
-			if err := json.NewEncoder(w).Encode(supercedences); err != nil {
-				return errors.Wrap(err, "failed to encode supercedence/supercedence.json.gz")
+			if err := writeGzipJSON("./dist/supercedence/supercedence.json.gz", supercedences); err != nil {
+				return errors.Wrap(err, "failed to write supercedence/supercedence.json.gz")
 			}
 		}
 		return nil
 	},
+}
+
+// writeGzipJSON writes v as gzip-compressed JSON to path. Because gzip.Writer
+// buffers and its Close flushes the remaining data and writes the stream
+// footer, a swallowed Close error can silently produce a truncated .gz; the
+// close errors of both the gzip writer and the underlying file are therefore
+// propagated via the named return.
+func writeGzipJSON(path string, v any) (err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.ModePerm)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %s", path)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = errors.Wrapf(cerr, "failed to close %s", path)
+		}
+	}()
+
+	w := gzip.NewWriter(f)
+	defer func() {
+		if cerr := w.Close(); cerr != nil && err == nil {
+			err = errors.Wrapf(cerr, "failed to close gzip writer for %s", path)
+		}
+	}()
+
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		return errors.Wrapf(err, "failed to encode %s", path)
+	}
+	return nil
 }
 
 func init() {

--- a/pkg/supercedence/builder/builder.go
+++ b/pkg/supercedence/builder/builder.go
@@ -33,7 +33,7 @@ func Build(dirs []string) ([]model.Supercedence, error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to open %s", path)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			var ss []model.Supercedence
 			if err := json.NewDecoder(f).Decode(&ss); err != nil {

--- a/pkg/supercedence/builder/builder.go
+++ b/pkg/supercedence/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/util"
 )
@@ -33,7 +34,7 @@ func Build(dirs []string) ([]model.Supercedence, error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to open %s", path)
 			}
-			defer func() { _ = f.Close() }()
+			defer closeutil.Quietly(f)
 
 			var ss []model.Supercedence
 			if err := json.NewDecoder(f).Decode(&ss); err != nil {

--- a/pkg/supercedence/cmd/fetch.go
+++ b/pkg/supercedence/cmd/fetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/fetcher/bulletin"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/fetcher/cvrf"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/fetcher/msuc"
@@ -49,7 +50,7 @@ var fetchSupercedenceCVRFCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/cvrf/%s.json", kbid)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/cvrf/%s.json", kbid)
 				}
@@ -89,7 +90,7 @@ var fetchSupercedenceBulletinCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/bulletin/%s.json", kbid)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/bulletin/%s.json", kbid)
 				}
@@ -129,7 +130,7 @@ var fetchSupercedenceWsusscn2Cmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/wsusscn2/%s.json", kbid)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/wsusscn2/%s.json", kbid)
 				}
@@ -169,7 +170,7 @@ var fetchSupercedenceMSUCCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/msuc/%s.json", kbid)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/msuc/%s.json", kbid)
 				}

--- a/pkg/supercedence/cmd/fetch.go
+++ b/pkg/supercedence/cmd/fetch.go
@@ -49,7 +49,7 @@ var fetchSupercedenceCVRFCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/cvrf/%s.json", kbid)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/cvrf/%s.json", kbid)
 				}
@@ -89,7 +89,7 @@ var fetchSupercedenceBulletinCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/bulletin/%s.json", kbid)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/bulletin/%s.json", kbid)
 				}
@@ -129,7 +129,7 @@ var fetchSupercedenceWsusscn2Cmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/wsusscn2/%s.json", kbid)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/wsusscn2/%s.json", kbid)
 				}
@@ -169,7 +169,7 @@ var fetchSupercedenceMSUCCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create supercedence/msuc/%s.json", kbid)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(ss); err != nil {
 					return errors.Wrapf(err, "failed to encode supercedence/msuc/%s.json", kbid)
 				}

--- a/pkg/supercedence/fetcher/bulletin/bulletin.go
+++ b/pkg/supercedence/fetcher/bulletin/bulletin.go
@@ -50,7 +50,7 @@ func fetch() ([]Bulletin, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		bs, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/supercedence/fetcher/bulletin/bulletin.go
+++ b/pkg/supercedence/fetcher/bulletin/bulletin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tealeg/xlsx"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/util"
 	winkb "github.com/vulsio/windows-vuln-feed/pkg/windows/kb"
@@ -50,7 +51,7 @@ func fetch() ([]Bulletin, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer func() { _ = resp.Body.Close() }()
+		defer closeutil.Quietly(resp.Body)
 
 		bs, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/supercedence/fetcher/bulletin/bulletin_test.go
+++ b/pkg/supercedence/fetcher/bulletin/bulletin_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 
 	"github.com/google/go-cmp/cmp"
@@ -43,7 +44,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer func() { _ = f.Close() }()
+		defer closeutil.Quietly(f)
 
 		bs, err := io.ReadAll(f)
 		if err != nil {

--- a/pkg/supercedence/fetcher/bulletin/bulletin_test.go
+++ b/pkg/supercedence/fetcher/bulletin/bulletin_test.go
@@ -43,7 +43,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		bs, err := io.ReadAll(f)
 		if err != nil {

--- a/pkg/supercedence/fetcher/cvrf/cvrf.go
+++ b/pkg/supercedence/fetcher/cvrf/cvrf.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/util"
 	winkb "github.com/vulsio/windows-vuln-feed/pkg/windows/kb"
@@ -57,7 +58,7 @@ func fetchCVRFURLs() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to do request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	var us updates
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
@@ -94,7 +95,7 @@ func fetchCVRFs(cvrfURLs []string) ([]cvrfdoc, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer func() { _ = resp.Body.Close() }()
+		defer closeutil.Quietly(resp.Body)
 
 		var root cvrfdoc
 		if err := xml.NewDecoder(resp.Body).Decode(&root); err != nil {

--- a/pkg/supercedence/fetcher/cvrf/cvrf.go
+++ b/pkg/supercedence/fetcher/cvrf/cvrf.go
@@ -57,7 +57,7 @@ func fetchCVRFURLs() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to do request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var us updates
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
@@ -94,7 +94,7 @@ func fetchCVRFs(cvrfURLs []string) ([]cvrfdoc, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		var root cvrfdoc
 		if err := xml.NewDecoder(resp.Body).Decode(&root); err != nil {

--- a/pkg/supercedence/fetcher/cvrf/cvrf_test.go
+++ b/pkg/supercedence/fetcher/cvrf/cvrf_test.go
@@ -131,7 +131,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		var root cvrfdoc
 		if err := xml.NewDecoder(f).Decode(&root); err != nil {

--- a/pkg/supercedence/fetcher/cvrf/cvrf_test.go
+++ b/pkg/supercedence/fetcher/cvrf/cvrf_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 )
 
@@ -131,7 +132,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer func() { _ = f.Close() }()
+		defer closeutil.Quietly(f)
 
 		var root cvrfdoc
 		if err := xml.NewDecoder(f).Decode(&root); err != nil {

--- a/pkg/supercedence/fetcher/msuc/msuc.go
+++ b/pkg/supercedence/fetcher/msuc/msuc.go
@@ -27,11 +27,7 @@ func FetchandParse(queries []string) ([]model.Supercedence, error) {
 		}
 
 		qs := uids
-		for {
-			if len(qs) == 0 {
-				break
-			}
-
+		for len(qs) != 0 {
 			var next []string
 			for _, uid := range qs {
 				if _, ok := uidtoKBID[uid]; ok {
@@ -96,7 +92,7 @@ func search(query string) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return ParseSearch(resp.Body)
 }
@@ -137,7 +133,7 @@ func view(updateID string) (model.Supercedence, error) {
 	if err != nil {
 		return model.Supercedence{}, errors.Wrap(err, "failed to send request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return ParseView(updateID, resp.Body)
 }

--- a/pkg/supercedence/fetcher/msuc/msuc.go
+++ b/pkg/supercedence/fetcher/msuc/msuc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 )
 
@@ -92,7 +93,7 @@ func search(query string) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	return ParseSearch(resp.Body)
 }
@@ -133,7 +134,7 @@ func view(updateID string) (model.Supercedence, error) {
 	if err != nil {
 		return model.Supercedence{}, errors.Wrap(err, "failed to send request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	return ParseView(updateID, resp.Body)
 }

--- a/pkg/supercedence/fetcher/msuc/msuc_test.go
+++ b/pkg/supercedence/fetcher/msuc/msuc_test.go
@@ -26,7 +26,7 @@ func Test_parseSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			got, err := msuc.ParseSearch(f)
 			if (err != nil) != tt.wantErr {
@@ -82,7 +82,7 @@ func TestParseView(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			got, err := msuc.ParseView(tt.args.uid, f)
 			if (err != nil) != tt.wantErr {

--- a/pkg/supercedence/fetcher/msuc/msuc_test.go
+++ b/pkg/supercedence/fetcher/msuc/msuc_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/fetcher/msuc"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 )
@@ -26,7 +27,7 @@ func Test_parseSearch(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer func() { _ = f.Close() }()
+			defer closeutil.Quietly(f)
 
 			got, err := msuc.ParseSearch(f)
 			if (err != nil) != tt.wantErr {
@@ -82,7 +83,7 @@ func TestParseView(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer func() { _ = f.Close() }()
+			defer closeutil.Quietly(f)
 
 			got, err := msuc.ParseView(tt.args.uid, f)
 			if (err != nil) != tt.wantErr {

--- a/pkg/supercedence/fetcher/wsusscn2/wsusscn2.go
+++ b/pkg/supercedence/fetcher/wsusscn2/wsusscn2.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/supercedence/model"
 )
 
@@ -65,13 +66,13 @@ func fetchWSUSSCN() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to do request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	f, err := os.Create(filepath.Join(dir, "wsusscn2.cab"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create wsusscn2.cab")
 	}
-	defer func() { _ = f.Close() }()
+	defer closeutil.Quietly(f)
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		return "", errors.Wrap(err, "failed to copy to wsusscn2.cab from response body")
@@ -102,7 +103,7 @@ func extractWSUSSCN(tmpDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open wsusscn2/index.xml")
 	}
-	defer func() { _ = f.Close() }()
+	defer closeutil.Quietly(f)
 
 	var cabIndex index
 	if err := xml.NewDecoder(f).Decode(&cabIndex); err != nil {
@@ -218,7 +219,7 @@ func walkPackage(packagePath string) (map[string]string, map[string][]string, er
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to open package.xml")
 	}
-	defer func() { _ = f.Close() }()
+	defer closeutil.Quietly(f)
 
 	var packages offlineSyncPackage
 	if err := xml.NewDecoder(f).Decode(&packages); err != nil {
@@ -244,7 +245,7 @@ func walkXDirs(cabDir string, rids []string) (map[string]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open wsusscn2/index.xml")
 	}
-	defer func() { _ = f.Close() }()
+	defer closeutil.Quietly(f)
 
 	var cabIndex index
 	if err := xml.NewDecoder(f).Decode(&cabIndex); err != nil {
@@ -294,7 +295,7 @@ func getKBID(rid, cabDir string, cabs []cab) (string, error) {
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to open wsusscn2/%s/x/%s", strings.TrimSuffix(c.NAME, ".cab"), rid)
 		}
-		defer func() { _ = f.Close() }()
+		defer closeutil.Quietly(f)
 
 		var xKBID xKBID
 		if err := xml.NewDecoder(f).Decode(&xKBID); err != nil {

--- a/pkg/supercedence/fetcher/wsusscn2/wsusscn2.go
+++ b/pkg/supercedence/fetcher/wsusscn2/wsusscn2.go
@@ -65,13 +65,13 @@ func fetchWSUSSCN() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to do request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	f, err := os.Create(filepath.Join(dir, "wsusscn2.cab"))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create wsusscn2.cab")
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		return "", errors.Wrap(err, "failed to copy to wsusscn2.cab from response body")
@@ -102,7 +102,7 @@ func extractWSUSSCN(tmpDir string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open wsusscn2/index.xml")
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var cabIndex index
 	if err := xml.NewDecoder(f).Decode(&cabIndex); err != nil {
@@ -218,7 +218,7 @@ func walkPackage(packagePath string) (map[string]string, map[string][]string, er
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to open package.xml")
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var packages offlineSyncPackage
 	if err := xml.NewDecoder(f).Decode(&packages); err != nil {
@@ -244,7 +244,7 @@ func walkXDirs(cabDir string, rids []string) (map[string]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open wsusscn2/index.xml")
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var cabIndex index
 	if err := xml.NewDecoder(f).Decode(&cabIndex); err != nil {
@@ -294,7 +294,7 @@ func getKBID(rid, cabDir string, cabs []cab) (string, error) {
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to open wsusscn2/%s/x/%s", strings.TrimSuffix(c.NAME, ".cab"), rid)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		var xKBID xKBID
 		if err := xml.NewDecoder(f).Decode(&xKBID); err != nil {

--- a/pkg/vulnerability/builder/builder.go
+++ b/pkg/vulnerability/builder/builder.go
@@ -32,7 +32,7 @@ func Build(dirs []string) ([]model.Vulnerability, error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to open %s", path)
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 
 			cve := model.Vulnerability{}
 			if err := json.NewDecoder(f).Decode(&cve); err != nil {

--- a/pkg/vulnerability/builder/builder.go
+++ b/pkg/vulnerability/builder/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/model"
 )
 
@@ -32,7 +33,7 @@ func Build(dirs []string) ([]model.Vulnerability, error) {
 			if err != nil {
 				return errors.Wrapf(err, "failed to open %s", path)
 			}
-			defer func() { _ = f.Close() }()
+			defer closeutil.Quietly(f)
 
 			cve := model.Vulnerability{}
 			if err := json.NewDecoder(f).Decode(&cve); err != nil {

--- a/pkg/vulnerability/cmd/fetch.go
+++ b/pkg/vulnerability/cmd/fetch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/fetcher/bulletin"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/fetcher/cvrf"
 )
@@ -42,7 +43,7 @@ var fetchVulerabilityCVRFCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create vulnerability/cvrf/%s.json", cve.CVEID)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(cve); err != nil {
 					return errors.Wrapf(err, "failed to encode vulnerability/cvrf/%s.json", cve.CVEID)
 				}
@@ -78,7 +79,7 @@ var fetchVulerabilityBulletinCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create vulnerability/bulletin/%s.json", cve.CVEID)
 				}
-				defer func() { _ = f.Close() }()
+				defer closeutil.Quietly(f)
 				if err := json.NewEncoder(f).Encode(cve); err != nil {
 					return errors.Wrapf(err, "failed to encode vulnerability/bulletin/%s.json", cve.CVEID)
 				}

--- a/pkg/vulnerability/cmd/fetch.go
+++ b/pkg/vulnerability/cmd/fetch.go
@@ -42,7 +42,7 @@ var fetchVulerabilityCVRFCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create vulnerability/cvrf/%s.json", cve.CVEID)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(cve); err != nil {
 					return errors.Wrapf(err, "failed to encode vulnerability/cvrf/%s.json", cve.CVEID)
 				}
@@ -78,7 +78,7 @@ var fetchVulerabilityBulletinCmd = &cobra.Command{
 				if err != nil {
 					return errors.Wrapf(err, "failed to create vulnerability/bulletin/%s.json", cve.CVEID)
 				}
-				defer f.Close()
+				defer func() { _ = f.Close() }()
 				if err := json.NewEncoder(f).Encode(cve); err != nil {
 					return errors.Wrapf(err, "failed to encode vulnerability/bulletin/%s.json", cve.CVEID)
 				}

--- a/pkg/vulnerability/fetcher/bulletin/bulletin.go
+++ b/pkg/vulnerability/fetcher/bulletin/bulletin.go
@@ -55,7 +55,7 @@ func fetch() ([]Bulletin, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		bs, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/vulnerability/fetcher/bulletin/bulletin.go
+++ b/pkg/vulnerability/fetcher/bulletin/bulletin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tealeg/xlsx"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/model"
 	winpro "github.com/vulsio/windows-vuln-feed/pkg/windows/product"
 )
@@ -55,7 +56,7 @@ func fetch() ([]Bulletin, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to do request")
 		}
-		defer func() { _ = resp.Body.Close() }()
+		defer closeutil.Quietly(resp.Body)
 
 		bs, err := io.ReadAll(resp.Body)
 		if err != nil {

--- a/pkg/vulnerability/fetcher/bulletin/bulletin_test.go
+++ b/pkg/vulnerability/fetcher/bulletin/bulletin_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tealeg/xlsx"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/model"
 )
 
@@ -162,7 +163,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer func() { _ = f.Close() }()
+		defer closeutil.Quietly(f)
 
 		bs, err := io.ReadAll(f)
 		if err != nil {

--- a/pkg/vulnerability/fetcher/bulletin/bulletin_test.go
+++ b/pkg/vulnerability/fetcher/bulletin/bulletin_test.go
@@ -162,7 +162,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		bs, err := io.ReadAll(f)
 		if err != nil {

--- a/pkg/vulnerability/fetcher/cvrf/cvrf.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf.go
@@ -63,7 +63,7 @@ func fetchCVRFURLs() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to do request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var us updates
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
@@ -97,7 +97,7 @@ func fetchCVRF(cvrfURL string) (Doc, error) {
 	if err != nil {
 		return Doc{}, errors.Wrap(err, "failed to do request")
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var root Doc
 	if err := xml.NewDecoder(resp.Body).Decode(&root); err != nil {

--- a/pkg/vulnerability/fetcher/cvrf/cvrf.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/model"
 	winkb "github.com/vulsio/windows-vuln-feed/pkg/windows/kb"
 	winpro "github.com/vulsio/windows-vuln-feed/pkg/windows/product"
@@ -63,7 +64,7 @@ func fetchCVRFURLs() ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to do request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	var us updates
 	if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
@@ -97,7 +98,7 @@ func fetchCVRF(cvrfURL string) (Doc, error) {
 	if err != nil {
 		return Doc{}, errors.Wrap(err, "failed to do request")
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer closeutil.Quietly(resp.Body)
 
 	var root Doc
 	if err := xml.NewDecoder(resp.Body).Decode(&root); err != nil {

--- a/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	"github.com/vulsio/windows-vuln-feed/pkg/closeutil"
 	"github.com/vulsio/windows-vuln-feed/pkg/vulnerability/model"
 )
 
@@ -204,7 +205,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer func() { _ = f.Close() }()
+		defer closeutil.Quietly(f)
 
 		var root Doc
 		if err := xml.NewDecoder(f).Decode(&root); err != nil {

--- a/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
@@ -204,7 +204,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("[%d] failed to open %s. err: %s", i, tt.input, err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		var root Doc
 		if err := xml.NewDecoder(f).Decode(&root); err != nil {


### PR DESCRIPTION
## Problem

The `lint` CI job (golangci-lint v2, run over the whole repo) has been failing on `main` for a long time — unrelated to any single feature. It reports **34 issues**, but the default `max-same-issues: 3` hides most of them, so each run surfaces a *different* subset (which makes it look inconsistent).

Full unfiltered list (`--max-same-issues=0 --max-issues-per-linter=0`): 32 `errcheck` + 2 `staticcheck`.

## Lint fixes (no behavior change)

- **32× errcheck** — unchecked `defer x.Close()`. Read-side / plain `*os.File`-write closes now go through a new `pkg/closeutil.Quietly(io.Closer)` helper (`defer closeutil.Quietly(x)`), replacing the repeated `defer func() { _ = x.Close() }()`. Named `closeutil` (not `util`) to avoid colliding with the existing `pkg/supercedence/util`.
- **staticcheck S1038** (`main.go`) — `fmt.Fprintln(os.Stderr, fmt.Sprintf(...))` → `fmt.Fprintf(os.Stderr, "%+v\n", err)`.
- **staticcheck QF1006** (`pkg/supercedence/fetcher/msuc/msuc.go`) — lift `if len(qs) == 0 { break }` into the loop condition (`for len(qs) != 0`).

## Write-path hardening (⚠️ intentional behavior change in failure scenarios)

Prompted by review: the `build` command's feed writer previously **swallowed** the `gzip.Writer`/file `Close()` errors, so a flush/footer failure could silently produce a **truncated** `.json.gz` while the command returned success.

- Extracted `writeGzipJSON(path, v)`: closes the gzip writer before the file, and combines the encode error with **both** Close errors via `errors.Join` so no failure is dropped.
- Generated feed files now use `0o644` instead of `os.ModePerm` (0777).

**Behavior change:** `build vulnerability` / `build supercedence` can now **fail** where they previously succeeded — specifically when finalizing/closing the compressed output errors (e.g. disk full). This is the intended, safer behavior (a hard failure instead of a silently corrupt feed), but it is a change in failure-path behavior, not a pure no-op. The lint fixes above remain behavior-preserving.

## Verification

Matched CI's linter version (v2.12.2):

- `golangci-lint run --timeout=10m --max-same-issues=0 --max-issues-per-linter=0` → **0 issues**
- `go build ./...` / `go vet ./...` → clean
- `go test ./...` → pass

## Note

This unblocks the `lint` check for other open PRs (e.g. #54), which were red only because of these pre-existing issues. Recommend merging this first, then rebasing those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)