### PR TITLE
fix(cvrf): accept index months with zero vulnerabilities

### DIFF
--- a/pkg/vulnerability/fetcher/cvrf/cvrf.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf.go
@@ -97,15 +97,15 @@ func collectVulnerabilities(targets []cvrfTarget) ([]model.Vulnerability, error)
 			return nil, errors.Wrapf(err, "failed to parse CVRF. url: %s", t.url)
 		}
 
-		// Layer 2: never accept an empty document silently. An index-listed
-		// month with zero vulnerabilities is the "200 but empty" dropout; treat
-		// it as an error so the downstream RemoveAll does not wipe the month.
+		// A zero-vulnerability document is a legitimate state, not a failure
+		// signal: out-of-band entries such as 2017-May-B ("May 8 2017 Security
+		// Updates") are listed in the index and permanently return HTTP 200 with
+		// no <Vulnerability>. So 0 vulnerabilities is accepted rather than
+		// treated as the "200 but empty" dropout. A genuinely missing month is
+		// instead caught above by a non-200 response (fromIndex -> error).
 		if len(cs) == 0 {
-			if !t.fromIndex {
-				log.Printf("INFO: skip supplemented month %s (0 vulnerabilities)", t.id)
-				continue
-			}
-			return nil, errors.Errorf("month %s is listed in the index but contains 0 vulnerabilities; refusing to proceed to avoid wiping existing data", t.id)
+			log.Printf("INFO: 0 CVEs found from %s", t.url)
+			continue
 		}
 
 		log.Printf("INFO: %d CVEs found from %s", len(cs), t.url)

--- a/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
+++ b/pkg/vulnerability/fetcher/cvrf/cvrf_test.go
@@ -386,9 +386,12 @@ func TestCollectVulnerabilities(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "index month with 0 vulnerabilities fails closed",
-			targets: []cvrfTarget{{id: "2026-Jul", url: u("/empty/2026-Jul"), fromIndex: true}},
-			wantErr: true,
+			// e.g. 2017-May-B ("May 8 2017 Security Updates"): listed in the
+			// index and permanently returns HTTP 200 with no <Vulnerability>.
+			// This is legitimate, not a dropout, so it must not fail the run.
+			name:     "index month with 0 vulnerabilities is accepted, not fatal",
+			targets:  []cvrfTarget{{id: "2017-May-B", url: u("/empty/2017-May-B"), fromIndex: true}},
+			wantCVEs: 0,
 		},
 		{
 			name:     "supplemented month unavailable is skipped, not fatal",
@@ -396,7 +399,7 @@ func TestCollectVulnerabilities(t *testing.T) {
 			wantCVEs: 0,
 		},
 		{
-			name:     "supplemented month with 0 vulnerabilities is skipped",
+			name:     "supplemented month with 0 vulnerabilities is accepted",
 			targets:  []cvrfTarget{{id: "2026-Jul", url: u("/empty/2026-Jul"), fromIndex: false}},
 			wantCVEs: 0,
 		},


### PR DESCRIPTION
## Problem (regression from #54)

The Layer 2 check added in #54 treats **any** index-listed month with 0 vulnerabilities as the "200 but empty" dropout and **hard-fails the entire `fetch vulnerability cvrf` run**:

```
month 2017-May-B is listed in the index but contains 0 vulnerabilities; refusing to proceed to avoid wiping existing data
```

But **0 vulnerabilities is a legitimate, permanent state.** `2017-May-B` ("May 8 2017 Security Updates") is a real out-of-band entry listed in `/updates` that always returns HTTP 200 with no `<Vulnerability>`:

```console
$ curl -s .../cvrf/v3.0/cvrf/2017-May-B | grep -c '<vuln:Vulnerability'
0    # HTTP 200, 3196 bytes, "May 8 2017 Security Updates"
```

Running the binary against the live MSRC API, the fetch aborts on `2017-May-B` and **writes no output at all** — strictly worse than the transient wipe #54 aimed to prevent (now it never updates). This was not caught in CI because the scheduled `Update Vuln Feed` job has been stuck `queued` (no runner); it was found by running the binary directly.

The current index contains **13** such zero-vulnerability months, so 0 vulnerabilities cannot be a failure signal — and a future `-B` release could be empty within the recent window too, so scoping the check to recent months wouldn't be safe either. This refutes the `msrc-cvrf-watch` premise that "200 with 0 vulns" implies a dropout.

## Fix

Accept a zero-vulnerability document instead of failing on it. What remains:

- **Layer 1 unchanged** — recent months are still always fetched (the actually-observed failure mode: a recent month dropping out of the index).
- A genuinely missing month is still caught by a **non-200** response (`fromIndex` → error; supplemented → skip).

## Verification (live MSRC API)

```
INFO: 0 CVEs found from .../cvrf/2017-May-B      <- accepted, not fatal
INFO: 355 CVEs found from .../cvrf/2026-Jul
INFO: 1205 CVEs found from .../cvrf/2026-Jun
INFO: 1123 CVEs found from .../cvrf/2026-May
INFO: 26187 CVEs found
```

Run completes; 13 empty months accepted; recent months fetched; 23,216 CVE JSON files written; no panic/error. `go build`, `go test ./...`, `golangci-lint` (v2.12.2, unfiltered) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)