### PR TITLE
fix(ci): use go.mod Go version for msuc-18/19 supercedence jobs

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -786,13 +786,13 @@ jobs:
     name: Fetch Microsoft Update Catalog - Windows 11 Version 23H2 (10.0.22631)
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Compile windows-vuln-feed
         run: make build
@@ -814,13 +814,13 @@ jobs:
     name: Fetch Microsoft Update Catalog - Windows 11 Version 24H2, Windows Server 2025 (10.0.26100)
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Compile windows-vuln-feed
         run: make build


### PR DESCRIPTION
## What

Only two jobs — `fetch-supercedence-msuc-18` (Windows 11 23H2) and `fetch-supercedence-msuc-19` (Windows 11 24H2 / Server 2025) — were still pinned to `actions/setup-go@v3` with `go-version: 1.18`, so `make build` failed in those jobs.

https://github.com/vulsio/windows-vuln-feed/actions/runs/31232326132

```
##[error]pkg/cmd/root.go:113:19: undefined: errors.Join
note: module requires Go 1.23
make: *** [GNUmakefile:10: build] Error 2
```

`errors.Join` was added in Go 1.20, so it cannot be compiled with Go 1.18.

## How

Aligned both jobs with the other 20 jobs in the workflow.

- `actions/setup-go@v3` / `go-version: 1.18` → `actions/setup-go@v5` / `go-version-file: go.mod`
- `actions/checkout@v3` → `actions/checkout@v4`
- Reordered the steps to checkout → Setup Go, matching the other jobs

## Note

The same run also emits Node 20 deprecation warnings for `actions/cache@v3` / `actions/cache/save@v3`. That is not the cause of this failure, so it is left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)